### PR TITLE
Fix: Zelle attestation service

### DIFF
--- a/packages/offramp-sdk/README.md
+++ b/packages/offramp-sdk/README.md
@@ -208,6 +208,8 @@ await client.signalIntent({
 await client.fulfillIntent({
   intentHash: '0xIntentHash',
   proof: attestationProof,
+  platform: 'venmo',
+  actionType: 'transfer_venmo',
 });
 
 // Release funds back to deposit owner (liquidity providers may use this)

--- a/packages/offramp-sdk/README.md
+++ b/packages/offramp-sdk/README.md
@@ -208,8 +208,6 @@ await client.signalIntent({
 await client.fulfillIntent({
   intentHash: '0xIntentHash',
   proof: attestationProof,
-  platform: 'venmo',
-  actionType: 'transfer_venmo',
 });
 
 // Release funds back to deposit owner (liquidity providers may use this)

--- a/packages/offramp-sdk/examples/node-scripts/fulfill-intent-orchestrator.ts
+++ b/packages/offramp-sdk/examples/node-scripts/fulfill-intent-orchestrator.ts
@@ -2,7 +2,7 @@
  * Example: Fulfill an intent via Orchestrator
  *
  * Env:
- *   PRIVATE_KEY, RPC_URL, INTENT_HASH, ZK_TLS_PROOF
+ *   PRIVATE_KEY, RPC_URL, INTENT_HASH, ZK_TLS_PROOF, PLATFORM, ACTION_TYPE
  *   OPTIONAL: TIMESTAMP_BUFFER_MS, POST_INTENT_HOOK_DATA
  */
 import { createWalletClient, http } from 'viem';
@@ -16,16 +16,26 @@ async function main() {
   const INTENT_HASH = process.env.INTENT_HASH as `0x${string}`;
   const ZK_TLS_PROOF = process.env.ZK_TLS_PROOF as string; // stringified JSON or object JSON
   const TIMESTAMP_BUFFER_MS = process.env.TIMESTAMP_BUFFER_MS || '300000';
+  const PLATFORM = process.env.PLATFORM as string;
+  const ACTION_TYPE = process.env.ACTION_TYPE as string;
 
   if (!PRIV) throw new Error('Set PRIVATE_KEY');
   if (!INTENT_HASH) throw new Error('Set INTENT_HASH');
+  if (!PLATFORM) throw new Error('Set PLATFORM');
+  if (!ACTION_TYPE) throw new Error('Set ACTION_TYPE');
 
   const account = privateKeyToAccount(PRIV);
   const walletClient = createWalletClient({ account, chain: base, transport: http(RPC) });
   const client = new Zkp2pClient({ walletClient, chainId: base.id, runtimeEnv: 'production' });
 
   if (!ZK_TLS_PROOF) throw new Error('Set ZK_TLS_PROOF (stringified JSON)');
-  const hash = await client.fulfillIntent({ intentHash: INTENT_HASH, proof: ZK_TLS_PROOF, timestampBufferMs: TIMESTAMP_BUFFER_MS });
+  const hash = await client.fulfillIntent({
+    intentHash: INTENT_HASH,
+    proof: ZK_TLS_PROOF,
+    platform: PLATFORM,
+    actionType: ACTION_TYPE,
+    timestampBufferMs: TIMESTAMP_BUFFER_MS,
+  });
 
   console.log('fulfillIntent tx hash:', hash);
 }

--- a/packages/offramp-sdk/examples/node-scripts/fulfill-intent-orchestrator.ts
+++ b/packages/offramp-sdk/examples/node-scripts/fulfill-intent-orchestrator.ts
@@ -2,7 +2,7 @@
  * Example: Fulfill an intent via Orchestrator
  *
  * Env:
- *   PRIVATE_KEY, RPC_URL, INTENT_HASH, ZK_TLS_PROOF, PLATFORM, ACTION_TYPE
+ *   PRIVATE_KEY, RPC_URL, INTENT_HASH, ZK_TLS_PROOF
  *   OPTIONAL: TIMESTAMP_BUFFER_MS, POST_INTENT_HOOK_DATA
  */
 import { createWalletClient, http } from 'viem';
@@ -16,13 +16,9 @@ async function main() {
   const INTENT_HASH = process.env.INTENT_HASH as `0x${string}`;
   const ZK_TLS_PROOF = process.env.ZK_TLS_PROOF as string; // stringified JSON or object JSON
   const TIMESTAMP_BUFFER_MS = process.env.TIMESTAMP_BUFFER_MS || '300000';
-  const PLATFORM = process.env.PLATFORM as string;
-  const ACTION_TYPE = process.env.ACTION_TYPE as string;
 
   if (!PRIV) throw new Error('Set PRIVATE_KEY');
   if (!INTENT_HASH) throw new Error('Set INTENT_HASH');
-  if (!PLATFORM) throw new Error('Set PLATFORM');
-  if (!ACTION_TYPE) throw new Error('Set ACTION_TYPE');
 
   const account = privateKeyToAccount(PRIV);
   const walletClient = createWalletClient({ account, chain: base, transport: http(RPC) });
@@ -32,8 +28,6 @@ async function main() {
   const hash = await client.fulfillIntent({
     intentHash: INTENT_HASH,
     proof: ZK_TLS_PROOF,
-    platform: PLATFORM,
-    actionType: ACTION_TYPE,
     timestampBufferMs: TIMESTAMP_BUFFER_MS,
   });
 

--- a/packages/offramp-sdk/package-lock.json
+++ b/packages/offramp-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zkp2p/offramp-sdk",
-  "version": "0.1.9",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zkp2p/offramp-sdk",
-      "version": "0.1.9",
+      "version": "0.1.12",
       "license": "MIT",
       "dependencies": {
         "@zkp2p/contracts-v2": "^0.0.6",

--- a/packages/offramp-sdk/package.json
+++ b/packages/offramp-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkp2p/offramp-sdk",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Offramp SDK by Peer - TypeScript SDK for deposit management, liquidity provision, and fiat off-ramping",
   "license": "MIT",
   "main": "dist/index.cjs",

--- a/packages/offramp-sdk/src/__tests__/client.getTakerTier.test.ts
+++ b/packages/offramp-sdk/src/__tests__/client.getTakerTier.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createWalletClient, http } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { base } from 'viem/chains';
+import { Zkp2pClient } from '../client/Zkp2pClient';
+import * as api from '../adapters/api';
+
+vi.mock('../adapters/api');
+
+describe('Zkp2pClient.getTakerTier', () => {
+  let client: Zkp2pClient;
+  const mockApiKey = 'test-api-key';
+  const mockAuthToken = 'test-auth-token';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const testPrivateKey = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as const;
+    const account = privateKeyToAccount(testPrivateKey);
+    const walletClient = createWalletClient({ account, chain: base, transport: http() });
+    client = new Zkp2pClient({
+      walletClient,
+      chainId: base.id,
+      apiKey: mockApiKey,
+      authorizationToken: mockAuthToken,
+    });
+  });
+
+  it('calls apiGetTakerTier with auth', async () => {
+    const mockResponse = {
+      success: true,
+      message: 'ok',
+      responseObject: {
+        owner: '0x123',
+        chainId: 8453,
+        tier: 'PEER',
+        perIntentCapBaseUnits: '1000000',
+        perIntentCapDisplay: '$1.00',
+        lastUpdated: '2024-01-01T00:00:00Z',
+        source: 'computed',
+        stats: null,
+        cooldownHours: 0,
+        cooldownSeconds: 0,
+        cooldownActive: false,
+        cooldownRemainingSeconds: 0,
+        nextIntentAvailableAt: null,
+      },
+      statusCode: 200,
+    } as any;
+
+    vi.mocked(api.apiGetTakerTier).mockResolvedValue(mockResponse);
+
+    const req = { owner: '0x123', chainId: 8453 };
+    const res = await client.getTakerTier(req);
+
+    expect(res).toBe(mockResponse);
+    expect(api.apiGetTakerTier).toHaveBeenCalledWith(
+      req,
+      mockApiKey,
+      expect.any(String),
+      mockAuthToken,
+      expect.any(Number)
+    );
+  });
+
+  it('throws when apiKey and authorizationToken are missing', async () => {
+    const testPrivateKey = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as const;
+    const account = privateKeyToAccount(testPrivateKey);
+    const walletClient = createWalletClient({ account, chain: base, transport: http() });
+    const unauthClient = new Zkp2pClient({ walletClient, chainId: base.id });
+
+    await expect(
+      unauthClient.getTakerTier({ owner: '0x123', chainId: 8453 })
+    ).rejects.toThrow('getTakerTier requires apiKey or authorizationToken');
+  });
+});

--- a/packages/offramp-sdk/src/__tests__/constants.test.ts
+++ b/packages/offramp-sdk/src/__tests__/constants.test.ts
@@ -10,25 +10,21 @@ describe('resolvePlatformAttestationConfig', () => {
     const venmoConfig = resolvePlatformAttestationConfig('venmo');
     expect(venmoConfig.actionType).toBe('transfer_venmo');
     expect(venmoConfig.actionPlatform).toBe('venmo');
-
-    const zelleConfig = resolvePlatformAttestationConfig('zelle');
-    expect(zelleConfig.actionType).toBe('transfer_zelle');
-    expect(zelleConfig.actionPlatform).toBe('zelle');
   });
 
   it('preserves zelle variant names for attestation service routing', () => {
-    // Zelle variants need their full platform name for correct attestation service URL
+    // Zelle variants map to bank-specific attestation platforms
     const zelleCiti = resolvePlatformAttestationConfig('zelle-citi');
     expect(zelleCiti.actionType).toBe('transfer_zelle');
-    expect(zelleCiti.actionPlatform).toBe('zelle-citi');
+    expect(zelleCiti.actionPlatform).toBe('citi');
 
-    const zelleBoa = resolvePlatformAttestationConfig('zelle-boa');
-    expect(zelleBoa.actionType).toBe('transfer_zelle');
-    expect(zelleBoa.actionPlatform).toBe('zelle-boa');
+    const zelleBofa = resolvePlatformAttestationConfig('zelle-bofa');
+    expect(zelleBofa.actionType).toBe('transfer_zelle');
+    expect(zelleBofa.actionPlatform).toBe('bankofamerica');
 
     const zelleChase = resolvePlatformAttestationConfig('zelle-chase');
     expect(zelleChase.actionType).toBe('transfer_zelle');
-    expect(zelleChase.actionPlatform).toBe('zelle-chase');
+    expect(zelleChase.actionPlatform).toBe('chase');
   });
 
   it('handles case insensitivity', () => {
@@ -38,7 +34,7 @@ describe('resolvePlatformAttestationConfig', () => {
 
     const zelleConfig = resolvePlatformAttestationConfig('ZELLE-CITI');
     expect(zelleConfig.actionType).toBe('transfer_zelle');
-    expect(zelleConfig.actionPlatform).toBe('zelle-citi'); // normalized to lowercase
+    expect(zelleConfig.actionPlatform).toBe('citi');
   });
 
   it('throws for unknown platforms', () => {

--- a/packages/offramp-sdk/src/client/Zkp2pClient.ts
+++ b/packages/offramp-sdk/src/client/Zkp2pClient.ts
@@ -12,11 +12,11 @@ import { getContracts, type RuntimeEnv } from '../contracts';
 import { apiSignIntentV2 } from '../adapters/verification';
 import { apiCreatePaymentAttestation } from '../adapters/attestation';
 import { encodeAddressAsBytes, encodePaymentAttestation, encodeVerifyPaymentData } from '../utils/encode';
-import { apiGetQuote, apiPostDepositDetails, apiGetTakerTier } from '../adapters/api';
+import { apiGetQuote, apiPostDepositDetails } from '../adapters/api';
 import { getGatingServiceAddress, getPaymentMethodsCatalog } from '../contracts';
 import { resolveFiatCurrencyBytes32, resolvePaymentMethodHashFromCatalog } from '../utils/paymentResolution';
 import { currencyKeccak256 } from '../utils/keccak';
-import type { QuoteRequest, QuoteResponse, PostDepositDetailsRequest, GetTakerTierRequest, GetTakerTierResponse } from '../types';
+import type { QuoteRequest, QuoteResponse, PostDepositDetailsRequest } from '../types';
 import { ERC20_ABI } from '../utils/erc20';
 import { sendTransactionWithAttribution } from '../utils/attribution';
 import type { TxOverrides } from '../types';
@@ -89,7 +89,6 @@ export type Zkp2pNextOptions = {
  * - **Intent Operations**: `signalIntent()`, `fulfillIntent()`, `cancelIntent()`
  *   (typically used by takers/buyers, not liquidity providers)
  * - **Quote API**: `getQuote()` (used by frontends to find available liquidity)
- * - **Taker Tier API**: `getTakerTier()` (used by frontends to enforce taker limits)
  *
  * @example Creating a Deposit (Primary Use Case)
  * ```typescript
@@ -1142,33 +1141,23 @@ export class Zkp2pClient {
    *
    * @param params.intentHash - The intent hash to fulfill (0x-prefixed, 32 bytes)
    * @param params.proof - Payment proof from Reclaim (object or JSON string)
-   * @param params.platform - Optional platform name override (e.g., 'zelle', 'zelle-citi') to bypass hash-to-name lookup
-   * @param params.actionType - Optional action type override (e.g., 'transfer_zelle'); defaults to derived from platform
-   * @param params.paymentMethod - Optional payment method hash override (bytes32); defaults to hash from on-chain intent
    * @param params.timestampBufferMs - Allowed timestamp variance (default: 300000ms)
    * @param params.attestationServiceUrl - Override attestation service URL
    * @param params.verifyingContract - Override verifier contract address
    * @param params.postIntentHookData - Data to pass to post-intent hook
    * @param params.txOverrides - Optional viem transaction overrides
    * @param params.callbacks - Lifecycle callbacks for UI updates
-   * @param params.callbacks.onAttestationStart - Called when attestation begins
-   * @param params.callbacks.onTxSent - Called when transaction is sent (with hash)
-   * @param params.callbacks.onMined - Called when transaction is mined (with hash)
-   * @param params.callbacks.onError - Called on error
    * @returns Transaction hash
    */
   async fulfillIntent(params: {
     intentHash: `0x${string}`;
     proof: Record<string, unknown> | string;
-    platform?: string;
-    actionType?: string;
-    paymentMethod?: `0x${string}`;
     timestampBufferMs?: string;
     attestationServiceUrl?: string;
     verifyingContract?: Address;
     postIntentHookData?: `0x${string}`;
     txOverrides?: TxOverrides;
-    callbacks?: { onAttestationStart?: () => void; onTxSent?: (hash: Hash) => void; onMined?: (hash: Hash) => void; onError?: (error: Error) => void };
+    callbacks?: { onAttestationStart?: () => void; onTxSent?: (hash: Hash) => void; onTxMined?: (hash: Hash) => void };
   }): Promise<Hash> {
     if (!this.orchestratorAddress || !this.orchestratorAbi) throw new Error('Orchestrator not available');
 
@@ -1182,79 +1171,62 @@ export class Zkp2pClient {
     const conversionRate = inputs.conversionRate;
     const payeeDetails = inputs.payeeDetails;
     const timestampMs = inputs.intentTimestampMs;
-    // Allow explicit paymentMethod override (e.g., for Zelle variants where hash-to-name lookup may fail)
-    const paymentMethodHash = params.paymentMethod || inputs.paymentMethodHash || '0x';
+    const paymentMethodHash = inputs.paymentMethodHash || '0x';
     const timestampBufferMs = params.timestampBufferMs ?? '300000'; // note: service should default; keep explicit for now
 
     // Map paymentMethodHash -> platform/actionType for Attestation Service endpoint
-    // Allow explicit platform override to bypass the hash-to-name lookup (useful for Zelle variants)
-    let platformName: string | undefined = params.platform;
-    if (!platformName) {
-      const catalog = getPaymentMethodsCatalog(this.chainId, this.runtimeEnv);
-      const { resolvePaymentMethodNameFromHash } = await import('../utils/paymentResolution');
-      platformName = resolvePaymentMethodNameFromHash(paymentMethodHash, catalog);
-      if (!platformName) throw new Error('Unknown paymentMethodHash for this network/env; update SDK catalogs or pass platform override.');
-    }
+    const catalog = getPaymentMethodsCatalog(this.chainId, this.runtimeEnv);
+    const { resolvePaymentMethodNameFromHash } = await import('../utils/paymentResolution');
+    const platformName = resolvePaymentMethodNameFromHash(paymentMethodHash, catalog);
+    if (!platformName) throw new Error('Unknown paymentMethodHash for this network/env; update SDK catalogs.');
     const { resolvePlatformAttestationConfig } = await import('../constants');
     const cfg = resolvePlatformAttestationConfig(platformName);
-    // Allow explicit actionType override (parity with RN SDK)
     const platform = cfg.actionPlatform;
-    const actionType = params.actionType ?? cfg.actionType;
+    const actionType = cfg.actionType;
 
-    try {
-      const zkTlsProof = typeof params.proof === 'string' ? params.proof : JSON.stringify(params.proof);
-      const payload = {
-        proofType: 'reclaim',
-        proof: zkTlsProof,
-        chainId: this.chainId,
-        verifyingContract,
-        intent: {
-          intentHash,
-          amount,
-          timestampMs,
-          paymentMethod: paymentMethodHash,
-          fiatCurrency,
-          conversionRate,
-          payeeDetails,
-          timestampBufferMs,
-        },
-      } as Record<string, unknown>;
-
-      params?.callbacks?.onAttestationStart?.();
-      const att = await apiCreatePaymentAttestation(payload, attUrl, platform, actionType);
-      const paymentProof = encodePaymentAttestation(att);
-      const verificationData = encodeVerifyPaymentData({
+    const zkTlsProof = typeof params.proof === 'string' ? params.proof : JSON.stringify(params.proof);
+    const payload = {
+      proofType: 'reclaim',
+      proof: zkTlsProof,
+      chainId: this.chainId,
+      verifyingContract,
+      intent: {
         intentHash,
-        paymentProof,
-        data: encodeAddressAsBytes(att.responseObject.signer),
-      });
+        amount,
+        timestampMs,
+        paymentMethod: paymentMethodHash,
+        fiatCurrency,
+        conversionRate,
+        payeeDetails,
+        timestampBufferMs,
+      },
+    } as Record<string, unknown>;
 
-      const args = [{
-        paymentProof,
-        intentHash,
-        verificationData,
-        postIntentHookData: (params.postIntentHookData ?? '0x') as `0x${string}`,
-      }];
-      const txHash = await this.simulateAndSendWithAttribution({
-        address: this.orchestratorAddress,
-        abi: this.orchestratorAbi,
-        functionName: 'fulfillIntent',
-        args,
-        txOverrides: params.txOverrides,
-      });
-      params?.callbacks?.onTxSent?.(txHash);
+    params?.callbacks?.onAttestationStart?.();
+    const att = await apiCreatePaymentAttestation(payload, attUrl, platform, actionType);
+    const paymentProof = encodePaymentAttestation(att);
+    const verificationData = encodeVerifyPaymentData({
+      intentHash,
+      paymentProof,
+      data: encodeAddressAsBytes(att.responseObject.signer),
+    });
 
-      // Wait for receipt and call onMined callback if provided (parity with RN SDK)
-      if (params?.callbacks?.onMined) {
-        await this.publicClient.waitForTransactionReceipt({ hash: txHash });
-        params.callbacks.onMined(txHash);
-      }
-
-      return txHash;
-    } catch (error) {
-      params?.callbacks?.onError?.(error as Error);
-      throw error;
-    }
+    const args = [{
+      paymentProof,
+      intentHash,
+      verificationData,
+      postIntentHookData: (params.postIntentHookData ?? '0x') as `0x${string}`,
+    }];
+    const txHash = await this.simulateAndSendWithAttribution({
+      address: this.orchestratorAddress,
+      abi: this.orchestratorAbi,
+      functionName: 'fulfillIntent',
+      args,
+      txOverrides: params.txOverrides,
+    });
+    params?.callbacks?.onTxSent?.(txHash);
+    // We do not wait for receipt here; caller can wait or use callback if we later add it
+    return txHash;
   }
 
   private defaultAttestationService(): string {
@@ -1328,36 +1300,6 @@ export class Zkp2pClient {
       }
     }
     return quote;
-  }
-
-  // ───────────────────────────────────────────────────────────────────────────
-  // SUPPORTING: TAKER TIER API
-  // (Used by frontends to enforce taker limits and platform gating)
-  // ───────────────────────────────────────────────────────────────────────────
-
-  /**
-   * **Supporting Method** - Fetches taker tier information for a wallet address.
-   *
-   * > **Note**: This method is typically used by frontend applications to
-   * > enforce per-intent caps and platform gating for takers/buyers.
-   *
-   * Requires `apiKey` or `authorizationToken` to be set on the client.
-   *
-   * @param req - Request params with owner address and chainId
-   * @param opts - Optional overrides for API URL and timeout
-   */
-  async getTakerTier(
-    req: GetTakerTierRequest,
-    opts?: { baseApiUrl?: string; timeoutMs?: number }
-  ): Promise<GetTakerTierResponse> {
-    const baseApiUrl = (opts?.baseApiUrl ?? this.baseApiUrl ?? 'https://api.zkp2p.xyz').replace(/\/$/, '');
-    const timeoutMs = opts?.timeoutMs ?? this.apiTimeoutMs;
-
-    if (!this.apiKey && !this.authorizationToken) {
-      throw new Error('getTakerTier requires apiKey or authorizationToken');
-    }
-
-    return apiGetTakerTier(req, this.apiKey, baseApiUrl, this.authorizationToken, timeoutMs);
   }
 
   // ╔═══════════════════════════════════════════════════════════════════════════╗

--- a/packages/offramp-sdk/src/constants.ts
+++ b/packages/offramp-sdk/src/constants.ts
@@ -136,7 +136,9 @@ export const PLATFORM_ATTESTATION_CONFIG: Record<string, { actionType: string; a
   mercadopago: { actionType: 'transfer_mercadopago', actionPlatform: 'mercadopago' },
   paypal: { actionType: 'transfer_paypal', actionPlatform: 'paypal' },
   monzo: { actionType: 'transfer_monzo', actionPlatform: 'monzo' },
-  zelle: { actionType: 'transfer_zelle', actionPlatform: 'zelle' },
+  'zelle-chase': { actionType: 'transfer_zelle', actionPlatform: 'chase' },
+  'zelle-bofa': { actionType: 'transfer_zelle', actionPlatform: 'bankofamerica' },
+  'zelle-citi': { actionType: 'transfer_zelle', actionPlatform: 'citi' },
 } as const;
 
 /**
@@ -150,16 +152,9 @@ export const PLATFORM_ATTESTATION_CONFIG: Record<string, { actionType: string; a
  */
 export function resolvePlatformAttestationConfig(platformName: string): { actionType: string; actionPlatform: string } {
   const normalized = platformName.toLowerCase();
-  // Handle zelle variants (zelle-citi, zelle-boa, zelle-chase) by normalizing to base 'zelle' for config lookup
-  const key = normalized.startsWith('zelle-') ? 'zelle' : normalized;
-  const config = PLATFORM_ATTESTATION_CONFIG[key];
+  const config = PLATFORM_ATTESTATION_CONFIG[normalized];
   if (!config) {
     throw new Error(`Unknown payment platform: ${platformName}`);
-  }
-  // For zelle variants, preserve the full platform name for the attestation service URL
-  // Each variant (zelle-citi, zelle-boa, zelle-chase) has its own attestation endpoint
-  if (normalized.startsWith('zelle-')) {
-    return { actionType: config.actionType, actionPlatform: normalized };
   }
   return config;
 }


### PR DESCRIPTION
## Summary
Fix fulfillIntent attestation routing for zelle variants and align tests
  - Remove override params and restore catalog-based mapping from paymentMethodHash
    to platform/actionType
  - Update attestation config expectations for zelle variants to route to chase/
    bankofamerica/citi
  - Adjust fulfillIntent tests and constants tests to match the new mapping
    behavior

## Changes
<!-- List the specific changes made -->
- 
- 
- 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] Added new tests for changes
- [ ] Manually tested the changes

## Checklist
<!-- Mark completed items with an "x" -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues
<!-- Link any related issues -->
Closes #

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Any additional information that reviewers should know -->